### PR TITLE
Removal of Xamarin Studio for Windows

### DIFF
--- a/SimpleWAWS/Resources/Client.resx
+++ b/SimpleWAWS/Resources/Client.resx
@@ -271,7 +271,7 @@
     <value>Install Visual Studio Professional 2015 (Update 2)</value>
   </data>
   <data name="Information_InstallXamarinStudio" xml:space="preserve">
-    <value>Install Xamarin Studio for Windows or OS X</value>
+    <value>Install Xamarin Studio for OS X</value>
   </data>
   <data name="Information_InstallXcode" xml:space="preserve">
     <value>Install Xcode (v4.4+)</value>

--- a/SimpleWAWS/Resources/Client.ru.resx
+++ b/SimpleWAWS/Resources/Client.ru.resx
@@ -271,7 +271,7 @@
     <value>Установить Visual Studio Professional 2015 (с обновлением 2)</value>
   </data>
   <data name="Information_InstallXamarinStudio" xml:space="preserve">
-    <value>Установить Xamarin Studio для Windows или OS X</value>
+    <value>Установить Xamarin Studio для OS X</value>
   </data>
   <data name="Information_InstallXcode" xml:space="preserve">
     <value>Установить Xcode (v4.4+)</value>

--- a/SimpleWAWS/Resources/client.cs.resx
+++ b/SimpleWAWS/Resources/client.cs.resx
@@ -271,7 +271,7 @@
     <value>Nainstalovat Visual Studio Professional 2015 (aktualizace 2)</value>
   </data>
   <data name="Information_InstallXamarinStudio" xml:space="preserve">
-    <value>Nainstalovat Xamarin Studio pro Windows nebo OS X</value>
+    <value>Nainstalovat Xamarin Studio pro OS X</value>
   </data>
   <data name="Information_InstallXcode" xml:space="preserve">
     <value>Nainstalovat Xcode (verze 4.4+)</value>

--- a/SimpleWAWS/Resources/client.de.resx
+++ b/SimpleWAWS/Resources/client.de.resx
@@ -271,7 +271,7 @@
     <value>Visual Studio Professional 2015 (Update 2) installieren</value>
   </data>
   <data name="Information_InstallXamarinStudio" xml:space="preserve">
-    <value>Xamarin Studio für Windows oder OS X installieren</value>
+    <value>Xamarin Studio für OS X installieren</value>
   </data>
   <data name="Information_InstallXcode" xml:space="preserve">
     <value>Xcode (v4.4+) installieren</value>

--- a/SimpleWAWS/Resources/client.en-us.resx
+++ b/SimpleWAWS/Resources/client.en-us.resx
@@ -271,7 +271,7 @@
     <value>Install Visual Studio Professional 2015 (Update 2)</value>
   </data>
   <data name="Information_InstallXamarinStudio" xml:space="preserve">
-    <value>Install Xamarin Studio for Windows or OS X</value>
+    <value>Install Xamarin Studio for OS X</value>
   </data>
   <data name="Information_InstallXcode" xml:space="preserve">
     <value>Install Xcode (v4.4+)</value>

--- a/SimpleWAWS/Resources/client.es.resx
+++ b/SimpleWAWS/Resources/client.es.resx
@@ -271,7 +271,7 @@
     <value>Instalar Visual Studio Professional 2015 (actualización 2)</value>
   </data>
   <data name="Information_InstallXamarinStudio" xml:space="preserve">
-    <value>Instalar Xamarin Studio para Windows u OS X</value>
+    <value>Instalar Xamarin Studio para OS X</value>
   </data>
   <data name="Information_InstallXcode" xml:space="preserve">
     <value>Instalar Xcode (v4.4+)</value>

--- a/SimpleWAWS/Resources/client.fr.resx
+++ b/SimpleWAWS/Resources/client.fr.resx
@@ -271,7 +271,7 @@
     <value>Installer Visual Studio Professional 2015 (Update 2)</value>
   </data>
   <data name="Information_InstallXamarinStudio" xml:space="preserve">
-    <value>Installer Xamarin Studio pour Windows ou OS X</value>
+    <value>Installer Xamarin Studio pour OS X</value>
   </data>
   <data name="Information_InstallXcode" xml:space="preserve">
     <value>Installer Xcode (v4.4+)</value>

--- a/SimpleWAWS/Resources/client.hu.resx
+++ b/SimpleWAWS/Resources/client.hu.resx
@@ -271,7 +271,7 @@
     <value>A Visual Studio Professional 2015 (Update 2) telepítése</value>
   </data>
   <data name="Information_InstallXamarinStudio" xml:space="preserve">
-    <value>A Windowshoz vagy az OS X-hez készült Xamarin Studio telepítése</value>
+    <value>A OS X-hez készült Xamarin Studio telepítése</value>
   </data>
   <data name="Information_InstallXcode" xml:space="preserve">
     <value>Xcode (v4.4+) telepítése</value>

--- a/SimpleWAWS/Resources/client.it.resx
+++ b/SimpleWAWS/Resources/client.it.resx
@@ -271,7 +271,7 @@
     <value>Installa Visual Studio Professional 2015 (Update 2)</value>
   </data>
   <data name="Information_InstallXamarinStudio" xml:space="preserve">
-    <value>Installa Xamarin Studio per Windows o OS X</value>
+    <value>Installa Xamarin Studio per OS X</value>
   </data>
   <data name="Information_InstallXcode" xml:space="preserve">
     <value>Installa Xcode (v4.4+)</value>

--- a/SimpleWAWS/Resources/client.nl.resx
+++ b/SimpleWAWS/Resources/client.nl.resx
@@ -271,7 +271,7 @@
     <value>Visual Studio Professional 2015 (update 2) installeren</value>
   </data>
   <data name="Information_InstallXamarinStudio" xml:space="preserve">
-    <value>Xamarin Studio voor Windows of OS X installeren</value>
+    <value>Xamarin Studio voor OS X installeren</value>
   </data>
   <data name="Information_InstallXcode" xml:space="preserve">
     <value>Xcode (v4.4+) installeren</value>

--- a/SimpleWAWS/Resources/client.pl.resx
+++ b/SimpleWAWS/Resources/client.pl.resx
@@ -271,7 +271,7 @@
     <value>Zainstaluj program Visual Studio Professional 2015 (Update 2)</value>
   </data>
   <data name="Information_InstallXamarinStudio" xml:space="preserve">
-    <value>Zainstaluj program Xamarin Studio dla systemu Windows lub OS X</value>
+    <value>Zainstaluj program Xamarin Studio dla systemu OS X</value>
   </data>
   <data name="Information_InstallXcode" xml:space="preserve">
     <value>Zainstaluj program Xcode (4.4+)</value>

--- a/SimpleWAWS/Resources/client.pt-br.resx
+++ b/SimpleWAWS/Resources/client.pt-br.resx
@@ -271,7 +271,7 @@
     <value>Instalar o Visual Studio Professional 2015 (Atualização 2)</value>
   </data>
   <data name="Information_InstallXamarinStudio" xml:space="preserve">
-    <value>Instalar o Xamarin Studio para Windows ou OS X</value>
+    <value>Instalar o Xamarin Studio para OS X</value>
   </data>
   <data name="Information_InstallXcode" xml:space="preserve">
     <value>Instalar o Xcode (v4.4+)</value>

--- a/SimpleWAWS/Resources/client.pt.resx
+++ b/SimpleWAWS/Resources/client.pt.resx
@@ -271,7 +271,7 @@
     <value>Instalar o Visual Studio Professional 2015 (Update 2)</value>
   </data>
   <data name="Information_InstallXamarinStudio" xml:space="preserve">
-    <value>Instalar o Xamarin Studio para Windows ou OS X</value>
+    <value>Instalar o Xamarin Studio para OS X</value>
   </data>
   <data name="Information_InstallXcode" xml:space="preserve">
     <value>Instalar o Xcode (v4.4+)</value>

--- a/SimpleWAWS/Resources/client.sv.resx
+++ b/SimpleWAWS/Resources/client.sv.resx
@@ -271,7 +271,7 @@
     <value>Installera Visual Studio Professional 2015 (Uppdatering 2)</value>
   </data>
   <data name="Information_InstallXamarinStudio" xml:space="preserve">
-    <value>Installera Xamarin Studio för Windows eller OS X</value>
+    <value>Installera Xamarin Studio för OS X</value>
   </data>
   <data name="Information_InstallXcode" xml:space="preserve">
     <value>Installera Xcode (v4.4+)</value>

--- a/SimpleWAWS/Resources/client.tr.resx
+++ b/SimpleWAWS/Resources/client.tr.resx
@@ -271,7 +271,7 @@
     <value>Visual Studio Professional 2015'i (Güncelleştirme 2) yükle</value>
   </data>
   <data name="Information_InstallXamarinStudio" xml:space="preserve">
-    <value>Windows veya OS X için Xamarin Studio'yu yükle</value>
+    <value>OS X için Xamarin Studio'yu yükle</value>
   </data>
   <data name="Information_InstallXcode" xml:space="preserve">
     <value>Xcode'u (v4.4+) yükle</value>

--- a/SimpleWAWS/Scripts/staticDataFactory.ts
+++ b/SimpleWAWS/Scripts/staticDataFactory.ts
@@ -151,8 +151,8 @@ angular.module("tryApp")
                        icon_url: "/Content/images/xamarin.png",
                        sprite: "mobile-icons sprite-xamarin",
                        steps: {
-                           preText: Resources.Information_InstallXamarinStudio,
-                           preHref: "https://go.microsoft.com/fwLink/?LinkID=330242&clcid=0x409",
+                           preText: Resources.Information_InstallVisualStudio,
+                           preHref: "https://go.microsoft.com/fwLink/?LinkID=391934&clcid=0x409",
                            clientText: Resources.Information_DownloadXamarinAndroidClient,
                            clientHref: "/api/resource/mobileclient/XamarinAndroid?templateName=TodoList"
                        }
@@ -161,8 +161,8 @@ angular.module("tryApp")
                        internal_name: "Xamarin.Forms",
                        sprite: "mobile-icons sprite-xamarin",
                        steps: {
-                           preText: Resources.Information_InstallXamarinStudio,
-                           preHref: "https://go.microsoft.com/fwLink/?LinkID=330242&clcid=0x409",
+                           preText: Resources.Information_InstallVisualStudio,
+                           preHref: "https://go.microsoft.com/fwLink/?LinkID=391934&clcid=0x409",
                            clientText: Resources.Information_DownloadXamarinFormsClient,
                            clientHref: "/api/resource/mobileclient/XamarinForms?templateName=TodoList"
                        }
@@ -239,8 +239,8 @@ angular.module("tryApp")
                         icon_url: "/Content/images/xamarin.png",
                         sprite: "mobile-icons sprite-xamarin",
                         steps: {
-                            preText: Resources.Information_InstallXamarinStudio,
-                            preHref: "https://go.microsoft.com/fwLink/?LinkID=330242&clcid=0x409",
+                            preText: Resources.Information_InstallVisualStudio,
+                            preHref: "https://go.microsoft.com/fwLink/?LinkID=391934&clcid=0x409",
                             clientText: Resources.Information_DownloadXamarinAndroidClient,
                             clientHref: "/api/resource/mobileclient/XamarinAndroid?templateName=XamarinCRM"
                         }


### PR DESCRIPTION
1) Updated text for the Information_InstallXamarinStudio to reflect that Xamarin Studio for Windows no longer exists.
2) Updated text across most languages (I don't grok cn/tw/jp so those are still the old text)
3) Updated the links in some mobile projects so that the Prerequisite is Xamarin for iOS projects and Visual Studio for Android and Forms Xamarin projects.